### PR TITLE
fix lazybuild path

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -191,7 +191,7 @@ fn addSslBackend(compile: *std.build.CompileStep, backend: SslBackend, ziget_rep
             {
                 const configure_openssl = std.build.RunStep.create(b, "configure openssl");
                 configure_openssl.step.dependOn(&openssl_repo.step);
-                configure_openssl.cwd = openssl_repo.getPath(&configure_openssl.step);
+                configure_openssl.cwd = .{ .path = openssl_repo.getPath(&configure_openssl.step) };
                 configure_openssl.addArgs(&[_][]const u8{
                     "./config",
                     // just a temporary path for now

--- a/loggyrunstep.zig
+++ b/loggyrunstep.zig
@@ -5,10 +5,10 @@ const print = std.debug.print;
 
 // This saves the RunStep.make function pointer because it is private
 var global_run_step_make: switch (builtin.zig_backend) {
-    .stage1 => ?fn(step: *std.build.Step, prog_node: *std.Progress.Node) anyerror!void,
-    else => ?*const fn(step: *std.build.Step, prog_node: *std.Progress.Node) anyerror!void,
+    .stage1 => ?fn (step: *std.build.Step, prog_node: *std.Progress.Node) anyerror!void,
+    else => ?*const fn (step: *std.build.Step, prog_node: *std.Progress.Node) anyerror!void,
 } = null;
-    
+
 pub fn enable(run_step: *RunStep) void {
     // TODO: use an atomic operation
     if (global_run_step_make) |make| {
@@ -30,7 +30,7 @@ fn printCmd(cwd: ?[]const u8, argv: []const []const u8) void {
 fn loggyRunStepMake(step: *std.build.Step, prog_node: *std.Progress.Node) !void {
     const self = @fieldParentPtr(RunStep, "step", step);
 
-    const cwd = if (self.cwd) |cwd| self.step.owner.pathFromRoot(cwd) else self.step.owner.build_root.path.?;
+    const cwd = if (self.cwd) |cwd| self.step.owner.pathFromRoot(cwd.path) else self.step.owner.build_root.path.?;
 
     var argv_list = std.ArrayList([]const u8).init(self.step.owner.allocator);
     for (self.argv.items) |arg| {


### PR DESCRIPTION
Tested on zig `0.12.0-dev.1139+4d106076c` version.

```bash
zig build -Doptimize=ReleaseFast --summary all
info: [RUN] "git" "clone" "https://github.com/marler8997/iguanaTLS" "/home/kassane/Documentos/ziget/dep/iguanaTLS"
Cloning into '/home/kassane/Documentos/ziget/dep/iguanaTLS'...
remote: Enumerating objects: 394, done.
remote: Counting objects: 100% (112/112), done.
remote: Compressing objects: 100% (35/35), done.
remote: Total 394 (delta 87), reused 90 (delta 76), pack-reused 282
Receiving objects: 100% (394/394), 236.62 KiB | 1.18 MiB/s, done.
Resolving deltas: 100% (239/239), done.
info: [RUN] "git" "-C" "/home/kassane/Documentos/ziget/dep/iguanaTLS" "checkout" "91d22df192d1df1022352df49f41c1a90ca8327d" "-b" "fordep"
Switched to a new branch 'fordep'
Build Summary: 4/4 steps succeeded
install success
└─ install ziget success
   └─ zig build-exe ziget ReleaseFast native success 15s MaxRSS:300M
      └─ clone git repository 'iguanaTLS' success
```

**Reference:**
- https://github.com/marler8997/zigup/issues/103

cc: @marler8997 